### PR TITLE
Use the new Settings API to register addon options.

### DIFF
--- a/ClassicPlatesPlus/Settings.lua
+++ b/ClassicPlatesPlus/Settings.lua
@@ -1027,9 +1027,13 @@ function func:Load_Settings()
     end
 
     -- Adding panels
-    for k,v in ipairs(data.settings.panels) do
-        if k then
-            InterfaceOptions_AddCategory(v);
+    local mainCategory = Settings.RegisterCanvasLayoutCategory(panelMain, panelMain.name)
+
+    for k, v in ipairs(data.settings.panels) do
+        if k and v.name ~= panelMain.name then
+            Settings.RegisterCanvasLayoutSubcategory(mainCategory, v, v.name)
         end
     end
+
+    Settings.RegisterAddOnCategory(mainCategory)
 end


### PR DESCRIPTION
With the new update to SOD version, 1.15.4, the classic era and Hardcore were also updated one step closer to retail, and now the once deprecated InterfaceOptions* functions were dropped.

https://github.com/Gethe/wow-ui-source/blob/1.15.2/Interface/SharedXML/Settings/Blizzard_Deprecated.lua

https://github.com/Gethe/wow-ui-source/blob/live/Interface/AddOns/Blizzard_Settings_Shared/Blizzard_ImplementationReadme.lua

This also fixes #10